### PR TITLE
add option to stream in raw/lossless formats and ability to set endianess

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,29 +44,55 @@ Select the lan IP address for the stream:
 2023/07/08 23:53:07 setting av1transport URI and playing
 ```
 
-There's also a `-debug` and `-headers` flags if you want to inspect your DLNA device
+There's also a `-debug` and `-headers` flags if you want to inspect your DLNA device. Also `-log` to inspect what parec and ffmpeg is doing. 
 
-### Flags for scripting
+### Non-interactive usage and extra flags
 
 ```
 [ugjka@ugjka blast]$ blast -h
 Usage of blast:
+  -bige
+        use big endian for capture and raw formats
   -bitrate int
-        mp3 bitrate (default 320)
+        audio format bitrate (default 320)
+  -bits int
+        audio bitdepth (default 16)
+  -channels int
+        audio channels (default 2)
   -chunk int
-        chunk size in seconds (default 1)
+        chunked size in seconds (default 1)
   -debug
         print debug info
   -device string
-        dlna friendly name
+        dlna device's friendly name
+  -dummy
+        only serve content
+  -format string
+        stream audio format (default "mp3")
   -headers
         print request headers
   -ip string
-        ip address
+        host ip address
+  -log
+        log parec and ffmpeg stderr
+  -mime string
+        stream mime type (default "audio/mpeg")
+  -nochunked
+        disable chunked tranfer endcoding
   -port int
         stream port (default 9000)
+  -rate int
+        audio sample rate (default 44100)
   -source string
         audio source (pactl list sources short | cut -f2)
+  -useaac
+        use aac audio
+  -useflac
+        use flac audio
+  -uselpcm
+        use lpcm audio
+  -usewav
+        use wav audio
 ```
 
 ## Building
@@ -96,7 +122,7 @@ This is for pipewire-pulse users.
 
 ## Caveats
 
-* You need to allow port 9000 from LAN for the DLNA receiver to be able to access the HTTP stream
+* You need to allow port 9000 from LAN for the DLNA receiver to be able to access the HTTP stream, you can change it with `-port` flag
 * blast monitor sink may not be visible in the pulse control applet unless you enable virtual streams
 
 ## Trivia

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -171,7 +171,7 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	go func() {
 		err := ffmpegCMD.Wait()
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "signal") {
 			log.Println("ffmpeg:", err)
 		}
 	}()

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -99,10 +99,6 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"--format="+fmt.Sprintf("s%dle", s.bitdepth),
 		"--raw",
 	)
-	if *logblast {
-		fmt.Fprintln(os.Stderr, strings.Join(parecCMD.Args, " "))
-		parecCMD.Stderr = os.Stderr
-	}
 
 	var raw bool
 	if s.format == "lpcm" || s.format == "wav" {
@@ -137,6 +133,8 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ffmpegCMD := exec.Command("ffmpeg", ffargs...)
 
 	if *logblast {
+		fmt.Fprintln(os.Stderr, strings.Join(parecCMD.Args, " "))
+		parecCMD.Stderr = os.Stderr
 		fmt.Fprintln(os.Stderr, strings.Join(ffmpegCMD.Args, " "))
 		ffmpegCMD.Stderr = os.Stderr
 	}

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -99,6 +99,7 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"--format", fmt.Sprintf("s%dle", s.bitdepth),
 	)
 	parecErrBuf := bytes.NewBuffer(nil)
+	parecCMD.Stderr = parecErrBuf
 
 	if s.format == "lpcm" {
 		s.format = fmt.Sprintf("s%dle", s.bitdepth)
@@ -117,6 +118,14 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"-b:a", fmt.Sprintf("%dk", s.bitrate),
 		)
 	}
+	if s.format == fmt.Sprintf("s%dle", s.bitdepth) {
+		ffargs = slices.Insert(
+			ffargs,
+			len(ffargs)-1,
+			"-c:a", fmt.Sprintf("pcm_s%dle", s.bitdepth),
+		)
+	}
+	//spew.Dump(strings.Join(ffargs, " "))
 	ffmpegCMD := exec.Command("ffmpeg", ffargs...)
 
 	ffmpegErrBuf := bytes.NewBuffer(nil)

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -146,7 +146,7 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 		buf := make([]byte, (s.bitrate/8)*1000*s.chunk)
 		if s.bitrate == 0 {
-			buf = make([]byte, s.samplerate*s.bitdepth*s.channels)
+			buf = make([]byte, s.samplerate*s.bitdepth*s.channels*s.chunk)
 		}
 		for {
 			n, err = ffmpegReader.Read(buf)

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -158,11 +158,23 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("parec failed: %v", err)
 		return
 	}
+	go func() {
+		err := parecCMD.Wait()
+		if err != nil && !strings.Contains(err.Error(), "signal") {
+			log.Println("parec:", err)
+		}
+	}()
 	err = ffmpegCMD.Start()
 	if err != nil {
 		log.Printf("ffmpeg failed: %v", err)
 		return
 	}
+	go func() {
+		err := ffmpegCMD.Wait()
+		if err != nil {
+			log.Println("ffmpeg:", err)
+		}
+	}()
 	if chunked {
 		var (
 			err error

--- a/audio_serve.go
+++ b/audio_serve.go
@@ -92,11 +92,12 @@ func (s stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	parecCMD := exec.Command(
 		"parec",
-		"--device", s.sink,
-		"--client-name", "blast-rec",
-		"--rate", fmt.Sprint(s.samplerate),
-		"--channels", fmt.Sprint(s.channels),
-		"--format", fmt.Sprintf("s%dle", s.bitdepth),
+		"--device="+s.sink,
+		"--client-name=blast-rec",
+		"--rate="+fmt.Sprint(s.samplerate),
+		"--channels="+fmt.Sprint(s.channels),
+		"--format="+fmt.Sprintf("s%dle", s.bitdepth),
+		"--raw",
 	)
 	parecErrBuf := bytes.NewBuffer(nil)
 	parecCMD.Stderr = parecErrBuf

--- a/audio_source.go
+++ b/audio_source.go
@@ -45,6 +45,7 @@ func chooseAudioSource(lookup string) (string, error) {
 	if len(srcJSON) == 0 {
 		return "", fmt.Errorf("no audio sources found")
 	}
+	// append for on-demand loading of blast sink
 	srcJSON = append(srcJSON, struct{ Name string }{BLASTMONITOR})
 	if lookup != "" {
 		for _, v := range srcJSON {
@@ -56,7 +57,6 @@ func chooseAudioSource(lookup string) (string, error) {
 	}
 
 	fmt.Println("Audio sources")
-	// append for on-demand loading of blast sink
 	for i, v := range srcJSON {
 		fmt.Printf("%d: %s\n", i, v.Name)
 	}

--- a/audio_source.go
+++ b/audio_source.go
@@ -30,7 +30,7 @@ import (
 	"os/exec"
 )
 
-func chooseAudioSource(lookup string) (source, error) {
+func chooseAudioSource(lookup string) (string, error) {
 	srcCMD := exec.Command("pactl", "-f", "json", "list", "sources", "short")
 	srcData, err := srcCMD.Output()
 	if err != nil {
@@ -49,7 +49,7 @@ func chooseAudioSource(lookup string) (source, error) {
 	if lookup != "" {
 		for _, v := range srcJSON {
 			if v.Name == lookup {
-				return source(lookup), nil
+				return lookup, nil
 			}
 		}
 		return "", fmt.Errorf("%s: not found", lookup)
@@ -65,7 +65,7 @@ func chooseAudioSource(lookup string) (source, error) {
 	fmt.Println("Select the audio source:")
 
 	selected := selector(srcJSON)
-	return source(srcJSON[selected].Name), nil
+	return srcJSON[selected].Name, nil
 }
 
 type Sources []struct {

--- a/av1transport.go
+++ b/av1transport.go
@@ -34,14 +34,14 @@ import (
 	"github.com/huin/goupnp/dcps/av1"
 )
 
-func AV1SetAndPlay(loc *url.URL, albumart, stream string) error {
+func AV1SetAndPlay(loc *url.URL, cf dlnaContentFeatures, logoURI, mimeType, streamURI string) error {
 	client, err := av1.NewAVTransport1ClientsByURL(loc)
 	if err != nil {
 		return err
 	}
 
 	try := func(metadata string) error {
-		err = client[0].SetAVTransportURI(0, stream, metadata)
+		err = client[0].SetAVTransportURI(0, streamURI, metadata)
 		if err != nil {
 			return fmt.Errorf("set uri: %v", err)
 		}
@@ -52,8 +52,10 @@ func AV1SetAndPlay(loc *url.URL, albumart, stream string) error {
 		}
 		return nil
 	}
-
-	metadata := didlMetadata(albumart, stream)
+	cf.profileName = ""
+	metadata := fmt.Sprintf(didlTemplate, logoURI, mimeType, cf, streamURI)
+	metadata = strings.ReplaceAll(metadata, "\n", " ")
+	metadata = strings.ReplaceAll(metadata, "> <", "><")
 	err = try(metadata)
 	if err == nil {
 		return nil
@@ -71,13 +73,6 @@ func AV1Stop(loc *url.URL) {
 	client[0].Stop(0)
 }
 
-func didlMetadata(albumart, stream string) string {
-	out := fmt.Sprintf(didlTemplate, albumart, stream)
-	out = strings.ReplaceAll(out, "\n", " ")
-	out = strings.ReplaceAll(out, "> <", "><")
-	return out
-}
-
 const didlTemplate = `<DIDL-Lite
 xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"
 xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
@@ -91,6 +86,9 @@ xmlns:pv="http://www.pv.com/pvns/">
 <dc:creator>Blast</dc:creator>
 <upnp:artist>Blast</upnp:artist>
 <upnp:albumArtURI>%s</upnp:albumArtURI>
-<res protocolInfo="http-get:*:audio/mpeg:*">%s</res>
+<res protocolInfo="http-get:*:%s:%s"
+bitsPerSample="16"
+sampleFrequency="44100"
+nrAudioChannels="2">%s</res>
 </item>
 </DIDL-Lite>`

--- a/dlna_content_features.go
+++ b/dlna_content_features.go
@@ -31,9 +31,15 @@ type dlnaContentFeatures struct {
 }
 
 func (c dlnaContentFeatures) String() (out string) {
-	out += fmt.Sprintf("DLNA.ORG_PN=%s;", c.profileName)
-	out += fmt.Sprintf("DLNA.ORG_OP=%d%d;", bti(c.supportTimeSeek), bti(c.supportRange))
-	out += fmt.Sprintf("DLNA.ORG_CI=%d;", bti(c.transcoded))
+	if c.profileName != "" {
+		out += fmt.Sprintf("DLNA.ORG_PN=%s;", c.profileName)
+	}
+	if c.supportTimeSeek || c.supportRange {
+		out += fmt.Sprintf("DLNA.ORG_OP=%d%d;", bti(c.supportTimeSeek), bti(c.supportRange))
+	}
+	if c.transcoded {
+		out += fmt.Sprintf("DLNA.ORG_CI=%d;", bti(c.transcoded))
+	}
 	out += formatDLNAFlags(c.flags)
 	return
 }

--- a/dlna_content_features_test.go
+++ b/dlna_content_features_test.go
@@ -7,15 +7,15 @@ import (
 func TestContentFeatures(t *testing.T) {
 	f := dlnaContentFeatures{
 		profileName:     "MP3",
-		supportTimeSeek: false,
+		supportTimeSeek: true,
 		supportRange:    false,
-		transcoded:      false,
+		transcoded:      true,
 		flags: DLNA_ORG_FLAG_STREAMING_TRANSFER_MODE |
 			DLNA_ORG_FLAG_BACKGROUND_TRANSFERT_MODE |
 			DLNA_ORG_FLAG_CONNECTION_STALL |
 			DLNA_ORG_FLAG_DLNA_V15,
 	}
-	want := "DLNA.ORG_PN=MP3;DLNA.ORG_OP=00;DLNA.ORG_CI=0;" +
+	want := "DLNA.ORG_PN=MP3;DLNA.ORG_OP=10;DLNA.ORG_CI=1;" +
 		"DLNA.ORG_FLAGS=01700000000000000000000000000000"
 	if f.String() != want {
 		t.Fatalf("got %s, wanted %s", f, want)

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 	headers := flag.Bool("headers", false, "print request headers")
 	logblast = flag.Bool("log", false, "log parec and ffmpeg stderr")
 	nochunked := flag.Bool("nochunked", false, "disable chunked tranfer endcoding")
+	bige := flag.Bool("bige", false, "use big endian for capture and raw formats")
 
 	flag.Parse()
 
@@ -202,6 +203,7 @@ func main() {
 		samplerate:   *rate,
 		channels:     *channels,
 		nochunked:    *nochunked,
+		bige:         *bige,
 	}
 	if *useaac {
 		streamHandler.format = "adts"

--- a/main.go
+++ b/main.go
@@ -69,25 +69,26 @@ func main() {
 			}
 		}
 	}
-	debug := flag.Bool("debug", false, "print debug info")
-	headers := flag.Bool("headers", false, "print request headers")
-	// script flags
 	device := flag.String("device", "", "dlna friendly name")
 	source := flag.String("source", "", "audio source (pactl list sources short | cut -f2)")
 	ip := flag.String("ip", "", "ip address")
-	bitrate := flag.Int("bitrate", 320, "format bitrate")
 	port := flag.Int("port", 9000, "stream port")
 	chunk := flag.Int("chunk", 1, "chunk size in seconds")
+	bitrate := flag.Int("bitrate", 320, "format bitrate")
 	format := flag.String("format", "mp3", "stream audio codec")
 	mime := flag.String("mime", "audio/mpeg", "stream mime type")
-	usewav := flag.Bool("usewav", false, "use wav audio")
-	uselpcm := flag.Bool("uselpcm", false, "use lpcm audio")
 	useaac := flag.Bool("useaac", false, "use aac audio")
+	useflac := flag.Bool("useflac", false, "use flac audio")
+	uselpcm := flag.Bool("uselpcm", false, "use lpcm audio")
+	usewav := flag.Bool("usewav", false, "use wav audio")
 	bits := flag.Int("bits", 16, "audio bitdepth")
 	rate := flag.Int("rate", 44100, "audio samplerate")
 	channels := flag.Int("channels", 2, "audio channels")
 	dummy := flag.Bool("dummy", false, "skip dlna device")
+	debug := flag.Bool("debug", false, "print debug info")
+	headers := flag.Bool("headers", false, "print request headers")
 	logblast = flag.Bool("log", false, "log parec and ffmpeg")
+	nochunked := flag.Bool("nochunked", false, "disable chunked tranfer endcoding")
 
 	flag.Parse()
 
@@ -200,10 +201,15 @@ func main() {
 		bitdepth:     *bits,
 		samplerate:   *rate,
 		channels:     *channels,
+		nochunked:    *nochunked,
 	}
-	if *usewav {
-		streamHandler.format = "wav"
-		streamHandler.mime = "audio/wav"
+	if *useaac {
+		streamHandler.format = "adts"
+		streamHandler.mime = "audio/aac"
+	}
+	if *useflac {
+		streamHandler.format = "flac"
+		streamHandler.mime = "audio/flac"
 		streamHandler.bitrate = 0
 	}
 	if *uselpcm {
@@ -211,9 +217,10 @@ func main() {
 		streamHandler.mime = fmt.Sprintf("audio/L%d;rate=%d;channels=%d", *bits, *rate, *channels)
 		streamHandler.bitrate = 0
 	}
-	if *useaac {
-		streamHandler.format = "adts"
-		streamHandler.mime = "audio/aac"
+	if *usewav {
+		streamHandler.format = "wav"
+		streamHandler.mime = "audio/wav"
+		streamHandler.bitrate = 0
 	}
 
 	streamHandler.contentfeat = dlnaContentFeatures{

--- a/main.go
+++ b/main.go
@@ -79,8 +79,9 @@ func main() {
 	format := flag.String("format", "mp3", "stream audio codec")
 	mime := flag.String("mime", "audio/mpeg", "stream mime type")
 	usewav := flag.Bool("usewav", false, "use wav audio")
-	bits := flag.Int("bits", 16, "audio bitdepth")
 	uselpcm := flag.Bool("uselpcm", false, "use lpcm audio")
+	useaac := flag.Bool("useaac", false, "use aac audio")
+	bits := flag.Int("bits", 16, "audio bitdepth")
 	rate := flag.Int("rate", 44100, "audio samplerate")
 	channels := flag.Int("channels", 2, "audio channels")
 
@@ -197,10 +198,16 @@ func main() {
 	if *usewav {
 		streamHandler.format = "wav"
 		streamHandler.mime = "audio/wav"
+		streamHandler.bitrate = 0
 	}
 	if *uselpcm {
 		streamHandler.format = "lpcm"
 		streamHandler.mime = fmt.Sprintf("audio/L%d;rate=%d;channels=%d", *bits, *rate, *channels)
+		streamHandler.bitrate = 0
+	}
+	if *useaac {
+		streamHandler.format = "adts"
+		streamHandler.mime = "audio/aac"
 	}
 
 	streamHandler.contentfeat = dlnaContentFeatures{

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	source := flag.String("source", "", "audio source (pactl list sources short | cut -f2)")
 	ip := flag.String("ip", "", "host ip address")
 	port := flag.Int("port", 9000, "stream port")
-	chunk := flag.Int("chunk", 1, "chunked size in secconds")
+	chunk := flag.Int("chunk", 1, "chunk size in seconds")
 	bitrate := flag.Int("bitrate", 320, "audio format bitrate")
 	format := flag.String("format", "mp3", "stream audio format")
 	mime := flag.String("mime", "audio/mpeg", "stream mime type")

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func main() {
 		protocol    = "http"
 	)
 
-	if !*dummy && detectSonos(DLNADevice) {
+	if !*dummy && *format == "mp3" && detectSonos(DLNADevice) {
 		protocol = "x-rincon-mp3radio"
 	}
 


### PR DESCRIPTION
TLDR:
```
[ugjka@ugjka blast]$ blast -h
Usage of blast:
  -bige
        use big endian for capture and raw formats
  -bitrate int
        audio format bitrate (default 320)
  -bits int
        audio bitdepth (default 16)
  -channels int
        audio channels (default 2)
  -chunk int
        chunk size in seconds (default 1)
  -debug
        print debug info
  -device string
        dlna device's friendly name
  -dummy
        only serve content
  -format string
        stream audio format (default "mp3")
  -headers
        print request headers
  -ip string
        host ip address
  -log
        log parec and ffmpeg stderr
  -mime string
        stream mime type (default "audio/mpeg")
  -nochunked
        disable chunked tranfer endcoding
  -port int
        stream port (default 9000)
  -rate int
        audio sample rate (default 44100)
  -source string
        audio source (pactl list sources short | cut -f2)
  -useaac
        use aac audio
  -useflac
        use flac audio
  -uselpcm
        use lpcm audio
  -usewav
        use wav audio
```